### PR TITLE
get rid of `Z_Realloc()`

### DIFF
--- a/rott/rt_main.c
+++ b/rott/rt_main.c
@@ -706,20 +706,6 @@ void CheckCommandLineParameters( void )
    }
 }
 
-static inline void *safe_realloc(void *ptr, size_t size)
-{
-    void *new_ptr;
-
-    new_ptr = realloc(ptr, size);
-
-    if (new_ptr == NULL && size != 0)
-    {
-        free(ptr);
-    }
-
-    return new_ptr;
-}
-
 void SetupWads( void )
 {
    char  *newargs[99];

--- a/rott/rt_util.c
+++ b/rott/rt_util.c
@@ -674,6 +674,22 @@ void SafeFree (void * ptr)
 	Z_Free (ptr);
 }
 
+void *safe_realloc (void *ptr, size_t size)
+{
+    void *new_ptr;
+
+    new_ptr = realloc(ptr, size);
+
+    if (new_ptr == NULL && size != 0)
+    {
+        free(ptr);
+        Error("safe_realloc: Could not realloc %lu bytes", (unsigned long) size);
+    }
+
+    return new_ptr;
+}
+
+
 /*
 ==============
 =

--- a/rott/rt_util.h
+++ b/rott/rt_util.h
@@ -29,6 +29,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define ERRORVERSIONROW 1
 #define ERRORVERSIONCOL 67
 
+#include "rt_def.h"
 #include "develop.h"
 
 extern  int    egacolor[16];
@@ -112,6 +113,7 @@ struct dosdate_t
 
 void _dos_getdate(struct dosdate_t *date);
 
+void *safe_realloc (void *ptr, size_t size);
 
 #if (SOFTERROR==1)
 

--- a/rott/w_wad.c
+++ b/rott/w_wad.c
@@ -137,10 +137,8 @@ void W_AddFile (char *_filename)
 //
 // Fill in lumpinfo
 //
-        Z_Realloc((void **)&lumpinfo,numlumps*sizeof(lumpinfo_t));
-//        lumpinfo = realloc (lumpinfo, numlumps*sizeof(lumpinfo_t));
-//        if (!lumpinfo)
-//           Error("W_AddFile: Could not realloc %ld bytes",numlumps*sizeof(lumpinfo_t));
+
+        lumpinfo = safe_realloc(lumpinfo, numlumps * sizeof(*lumpinfo));
         lump_p = &lumpinfo[startlump];
 
         for (i=startlump ; i<(unsigned int)numlumps ; i++,lump_p++, fileinfo++)
@@ -198,7 +196,7 @@ void W_InitMultipleFiles (char **filenames)
 // open all the files, load headers, and count lumps
 //
         numlumps = 0;
-        lumpinfo = SafeMalloc(5);   // will be realloced as lumps are added
+        lumpinfo = NULL;   // will be realloced as lumps are added
 
         for ( ; *filenames ; filenames++)
                 W_AddFile (*filenames);

--- a/rott/z_zone.c
+++ b/rott/z_zone.c
@@ -204,24 +204,6 @@ void Z_ChangeTag(void *ptr, pu_tag tag)
   block->tag = tag;
 }
 
-void Z_Realloc (void **ptr, size_t newsize)
-{
-    memblock_t *block;
-    void *newptr;
-    size_t oldsize;
-
-    block = (memblock_t *) ((char *)(*ptr) - HEADER_SIZE);
-    oldsize = block->size;
-    newptr = SafeMalloc(newsize);
-    if (oldsize > newsize)
-    {
-        oldsize = newsize;
-    }
-    memcpy(newptr, *ptr, oldsize);
-    SafeFree(*ptr);
-    *ptr = newptr;
-}
-
 size_t Z_HeapSize (void)
 {
     return (size_t)MAXMEMORYSIZE;

--- a/rott/z_zone.h
+++ b/rott/z_zone.h
@@ -70,7 +70,6 @@ void Z_ChangeTag (void *ptr, pu_tag tag);          // Change the tag of a memory
 size_t Z_HeapSize ( void );                        // Return the total heap size
 size_t Z_UsedHeap ( void );                        // Return used portion of heap size
 void Z_ShutDown( void );
-void Z_Realloc (void **ptr, size_t newsize);
 
 #define Z_LevelMalloc(a,b,c) Z_Malloc(a,b,c)
 #define Z_UsedLevelHeap() Z_UsedHeap()


### PR DESCRIPTION
It was only used in one occasion, i.e. for the `lumpinfo[]` array and we can just as well use stdlib's `realloc()` there.