### PR TITLE
get rid of `GetPathFromEnvironment()` and `FixFilePath()`

### DIFF
--- a/rott/dukemusc.c
+++ b/rott/dukemusc.c
@@ -299,13 +299,13 @@ musdebug("Need to use PlaySongROTT.  :(");
 // ROTT Special - SBF
 int MUSIC_PlaySongROTT(unsigned char *song, int size, int loopflag)
 {
-    char filename[MAX_PATH];
+    char *filename;
     int handle;
     
     MUSIC_StopSong();
 
     // save the file somewhere, so SDL_mixer can load it
-    GetPathFromEnvironment(filename, ApogeePath, "tmpsong.mid");
+    filename = M_StringJoin(ApogeePath, PATH_SEP_STR, "tmpsong.mid", NULL);
     handle = SafeOpenWrite(filename);
     
     SafeWrite(handle, song, size);
@@ -315,6 +315,7 @@ int MUSIC_PlaySongROTT(unsigned char *song, int size, int loopflag)
 
     // finally, we can load it with SDL_mixer
     music_musicchunk = Mix_LoadMUS(filename);
+    free(filename);
     if (music_musicchunk == NULL) {
         return MUSIC_Error;
     }

--- a/rott/rt_cfg.c
+++ b/rott/rt_cfg.c
@@ -137,9 +137,9 @@ char CodeName[MAXCODENAMELENGTH];
 void ReadScores (void)
 {
    int file;
-   char filename[ 128 ];
+   char *filename;
 
-   GetPathFromEnvironment( filename, ApogeePath, ScoresName );
+   filename = M_StringJoin(ApogeePath, PATH_SEP_STR, ScoresName, NULL);
    if (access (filename, F_OK) == 0)
       {
       file = SafeOpenRead (filename);
@@ -148,6 +148,7 @@ void ReadScores (void)
       }
    else
       gamestate.violence = 0;
+   free(filename);
 }
 
 //******************************************************************************
@@ -858,10 +859,11 @@ void SetConfigDefaultValues (void)
 //******************************************************************************
 void DeleteSoundFile ( void )
 {
-   char filename[ 128 ];
+   char *filename;
 
-   GetPathFromEnvironment( filename, ApogeePath, SoundName );
+   filename = M_StringJoin(ApogeePath, PATH_SEP_STR, SoundName, NULL);
    unlink (filename);          // Delete SOUND.ROT
+   free(filename);
 }
 
 //******************************************************************************
@@ -873,9 +875,9 @@ void DeleteSoundFile ( void )
 
 void ReadConfig (void)
 {
-   char filename[ 128 ];
+   char *filename;
 
-   GetPathFromEnvironment( filename, ApogeePath, SoundName );
+   filename = M_StringJoin(ApogeePath, PATH_SEP_STR, SoundName, NULL);
    SetSoundDefaultValues ();
 
    if (access (filename, F_OK) == 0)
@@ -891,8 +893,9 @@ void ReadConfig (void)
       }
 
    ReadScores();
+   free(filename);
 
-   GetPathFromEnvironment( filename, ApogeePath, ConfigName );
+   filename = M_StringJoin(ApogeePath, PATH_SEP_STR, ConfigName, NULL);
    SetConfigDefaultValues ();
    if (access(filename,F_OK)==0)
       {
@@ -905,8 +908,9 @@ void ReadConfig (void)
 
       Z_Free(scriptbuffer);
       }
+   free(filename);
 
-   GetPathFromEnvironment( filename, ApogeePath, BattleName );
+   filename = M_StringJoin(ApogeePath, PATH_SEP_STR, BattleName, NULL);
    SetBattleDefaultValues ();
    if (access(filename,F_OK)==0)
       {
@@ -920,6 +924,7 @@ void ReadConfig (void)
       Z_Free(scriptbuffer);
       }
    ConfigLoaded = true;
+   free(filename);
 }
 
 //******************************************************************************
@@ -944,9 +949,9 @@ void CheckVendor (void)
    int size;
    int lump;
    byte * vendor;
-   char filename[ 128 ];
+   char *filename;
 
-   GetPathFromEnvironment( filename, ApogeePath, VENDORDOC );
+   filename = M_StringJoin(ApogeePath, PATH_SEP_STR, VENDORDOC, NULL);
    if (access (filename, F_OK) == 0)
       {
       size = LoadFile(filename,(void **)&vendor);
@@ -969,6 +974,7 @@ void CheckVendor (void)
       size = W_LumpLength(lump);
       SaveFile (filename,vendor,size);
       }
+   free(filename);
 }
 
 //******************************************************************************
@@ -1033,12 +1039,13 @@ void WriteParameterHex (int file, const char * s1, int val)
 void WriteScores (void)
 {
    int file;
-   char filename[ 128 ];
+   char *filename;
 
-   GetPathFromEnvironment( filename, ApogeePath, ScoresName );
+   filename = M_StringJoin(ApogeePath, PATH_SEP_STR, ScoresName, NULL);
    file=SafeOpenWrite( filename );
    SafeWrite (file, &Scores, sizeof (Scores));
    close(file);
+   free(filename);
 }
 
 
@@ -1056,11 +1063,11 @@ void WriteBattleConfig
    {
    int  file;
    int  index;
-   char filename[ 128 ];
+   char *filename;
    extern specials BattleSpecialsTimes;
 
    // Write Battle File
-   GetPathFromEnvironment( filename, ApogeePath, BattleName );
+   filename = M_StringJoin(ApogeePath, PATH_SEP_STR, BattleName, NULL);
    file = open( filename, O_RDWR | O_TEXT | O_CREAT | O_TRUNC,
       S_IREAD | S_IWRITE );
 
@@ -1068,6 +1075,8 @@ void WriteBattleConfig
       {
       Error( "Error opening %s: %s", filename, strerror( errno ) );
       }
+
+   free(filename);
 
    // Write out BATTLECONFIG header
    SafeWriteString( file,
@@ -1410,19 +1419,21 @@ void WriteSoundConfig
 
    {
    int file;
-   char filename[ 128 ];
+   char *filename;
 
    if ( !WriteSoundFile )
       {
       return;
       }
 
-   GetPathFromEnvironment( filename, ApogeePath, SoundName );
+   filename = M_StringJoin(ApogeePath, PATH_SEP_STR, SoundName, NULL);
    file = open ( filename, O_RDWR | O_TEXT | O_CREAT | O_TRUNC,
       S_IREAD | S_IWRITE);
 
    if (file == -1)
       Error ("Error opening %s: %s", filename, strerror(errno));
+
+   free(filename);
 
    // Write out ROTTSOUND header
 
@@ -1507,7 +1518,7 @@ void WriteSoundConfig
 void WriteConfig (void)
 {
    int file;
-   char filename[ 128 ];
+   char *filename;
    char passwordtemp[50];
    static int inconfig = 0;
 
@@ -1528,12 +1539,14 @@ void WriteConfig (void)
    WriteScores();
    WriteBattleConfig();
 
-   GetPathFromEnvironment( filename, ApogeePath, ConfigName );
+   filename = M_StringJoin(ApogeePath, PATH_SEP_STR, ConfigName, NULL);
    file = open( filename,O_RDWR | O_TEXT | O_CREAT | O_TRUNC
    , S_IREAD | S_IWRITE);
 
    if (file == -1)
       Error ("Error opening %s: %s",filename,strerror(errno));
+
+   free(filename);
 
    // Write out ROTTCONFIG header
 
@@ -1891,7 +1904,7 @@ void GetAlternateFile (char * tokenstr, AlternateInformation *info)
 
 void ReadSETUPFiles (void)
 {
-   char filename[ 128 ];
+   char *filename;
    int i;
 
    RemoteSounds.avail   = false;
@@ -1899,7 +1912,7 @@ void ReadSETUPFiles (void)
    GameLevels.avail     = false;
    BattleLevels.avail   = false;
 
-   GetPathFromEnvironment( filename, ApogeePath, CONFIG );
+   filename = M_StringJoin(ApogeePath, PATH_SEP_STR, CONFIG, NULL);
    if (access (filename, F_OK) == 0)
    {
       LoadScriptFile (filename);
@@ -1956,8 +1969,9 @@ void ReadSETUPFiles (void)
 
       Z_Free (scriptbuffer);
    }
+   free(filename);
 
-   GetPathFromEnvironment( filename, ApogeePath, ROTT );
+   filename = M_StringJoin(ApogeePath, PATH_SEP_STR, ROTT, NULL);
    if (access (filename, F_OK) == 0)
    {
       LoadScriptFile (filename);
@@ -1973,4 +1987,5 @@ void ReadSETUPFiles (void)
 
       unlink (filename);          // Delete ROTT.ROT
    }
+   free(filename);
 }

--- a/rott/rt_game.c
+++ b/rott/rt_game.c
@@ -4621,8 +4621,8 @@ void SaveTag (int handle, char * tag, int size)
 
 boolean SaveTheGame (int num, gamestorage_t * game)
 {
-   char   loadname[MAX_PATH]="rottgam0.rot";
-   char   filename[MAX_PATH];
+   char   loadname[]="rottgam0.rot";
+   char   *filename;
    byte   * altbuffer;
 	int    size;
    int    savehandle;
@@ -4652,7 +4652,7 @@ boolean SaveTheGame (int num, gamestorage_t * game)
    loadname[8]='.';
 
 
-   GetPathFromEnvironment( filename, ApogeePath, loadname );
+   filename = M_StringJoin(ApogeePath, PATH_SEP_STR, loadname, NULL);
 
    // Open the savegame file
 
@@ -4857,6 +4857,7 @@ boolean SaveTheGame (int num, gamestorage_t * game)
    size=sizeof(crc);
    SafeWrite(savehandle,&crc,size);
 
+   free(filename);
    close (savehandle);
 
    pickquick = true;
@@ -4905,8 +4906,8 @@ int LoadBuffer (byte ** dest, byte ** src)
 
 boolean LoadTheGame (int num, gamestorage_t * game)
 {
-   char   loadname[45]="rottgam0.rot";
-   char   filename[128];
+   char   loadname[]="rottgam0.rot";
+   char   *filename;
    byte   * loadbuffer;
 	byte   * bufptr;
 	byte   * altbuffer;
@@ -4926,12 +4927,13 @@ boolean LoadTheGame (int num, gamestorage_t * game)
    itoa(num,&loadname[7],16);
    loadname[8]='.';
 
-   GetPathFromEnvironment( filename, ApogeePath, loadname );
+   filename = M_StringJoin(ApogeePath, PATH_SEP_STR, loadname, NULL);
 
    // Load the file
 
 	totalsize=LoadFile(filename,(void **)&loadbuffer);
 	bufptr=loadbuffer;
+	free(filename);
 
 	// Calculate checksum
 
@@ -5255,8 +5257,8 @@ boolean LoadTheGame (int num, gamestorage_t * game)
 void GetSavedMessage (int num, char * message)
 {
    gamestorage_t game;
-   char   loadname[45]="rottgam0.rot";
-   char   filename[128];
+   char   loadname[]="rottgam0.rot";
+   char   *filename;
    byte   * loadbuffer;
    byte   * bufptr;
    int    size;
@@ -5269,12 +5271,13 @@ void GetSavedMessage (int num, char * message)
    itoa(num,&loadname[7],16);
    loadname[8]='.';
 
-   GetPathFromEnvironment( filename, ApogeePath, loadname );
+   filename = M_StringJoin(ApogeePath, PATH_SEP_STR, loadname, NULL);
 
    // Load the file
 
    size=LoadFile(filename,(void **)&loadbuffer);
    bufptr=loadbuffer;
+   free(filename);
 
    size=4;
    LoadTag(&bufptr,"ROTT",size);
@@ -5297,8 +5300,8 @@ void GetSavedMessage (int num, char * message)
 
 void GetSavedHeader (int num, gamestorage_t * game)
 {
-   char   loadname[45]="rottgam0.rot";
-   char   filename[128];
+   char   loadname[]="rottgam0.rot";
+   char   *filename;
    byte   * loadbuffer;
    byte   * bufptr;
    int    size;
@@ -5311,12 +5314,13 @@ void GetSavedHeader (int num, gamestorage_t * game)
    itoa(num,&loadname[7],16);
    loadname[8]='.';
 
-   GetPathFromEnvironment( filename, ApogeePath, loadname );
+   filename = M_StringJoin(ApogeePath, PATH_SEP_STR, loadname, NULL);
 
    // Load the file
 
    size=LoadFile(filename, (void **)&loadbuffer);
    bufptr=loadbuffer;
+   free(filename);
 
    size=4;
    LoadTag(&bufptr,"ROTT",size);

--- a/rott/rt_menu.c
+++ b/rott/rt_menu.c
@@ -2246,18 +2246,19 @@ int HandleMenu (CP_iteminfo *item_i, CP_itemtype *items, void (*routine)(int w))
          {
             if (CP_DisplayMsg ("Delete saved game?\nAre you sure?", 12) == true)
             {
-               char loadname[45] = "rottgam0.rot";
-               char filename[128];
+               char loadname[] = "rottgam0.rot";
+               char *filename;
 
                // Create the proper file name
                itoa (handlewhich, &loadname[7], 16);
                loadname[8]='.';
 
-               GetPathFromEnvironment( filename, ApogeePath, loadname );
+               filename = M_StringJoin(ApogeePath, PATH_SEP_STR, loadname, NULL);
 
                // Delete the file
 
 					unlink (filename);
+					free(filename);
 
                memset (&SaveGameNames[handlewhich][0], 0, 32);
                SaveGamesAvail[handlewhich] = 0;
@@ -3267,18 +3268,19 @@ int DoLoad (int which)
       {
          if (CP_DisplayMsg ("Saved Game is\n old or incompatible\nDelete it?", 12)==true)
          {
-            char loadname[45] = "rottgam0.rot";
-            char filename[128];
+            char loadname[] = "rottgam0.rot";
+            char *filename;
 
             // Create the proper file name
             itoa (which, &loadname[7], 16);
             loadname[8]='.';
 
-            GetPathFromEnvironment( filename, ApogeePath, loadname );
+            filename = M_StringJoin(ApogeePath, PATH_SEP_STR, loadname, NULL);
 
             // Delete the file
 
             unlink (filename);
+            free(filename);
 
             memset (&SaveGameNames[which][0], 0, 32);
             SaveGamesAvail[which] = 0;
@@ -3385,18 +3387,20 @@ void QuickSaveGame (void)
    byte * buf;
    int length;
 
-   char   loadname[45]="rottgam0.rot";
-   char   filename[128];
+   char   loadname[]="rottgam0.rot";
+   char   *filename;
 
    // Create the proper file name
 
    itoa(quicksaveslot,&loadname[7],16);
    loadname[8]='.';
 
-   GetPathFromEnvironment( filename, ApogeePath, loadname );
+   filename = M_StringJoin(ApogeePath, PATH_SEP_STR, loadname, NULL);
    length=LoadFile(filename,(void **)&buf);
-   GetPathFromEnvironment( filename, ApogeePath, QUICKSAVEBACKUP );
+   free(filename)
+   filename = M_StringJoin(ApogeePath, PATH_SEP_STR, QUICKSAVEBACKUP, NULL);
    SaveFile(filename,buf,length);
+   free(filename)
    SafeFree(buf);
 
    s=&game.picture[0];
@@ -3446,8 +3450,8 @@ void QuickSaveGame (void)
 void UndoQuickSaveGame (void)
 {
    byte * buf;
-   char   loadname[45]="rottgam0.rot";
-   char   filename[128];
+   char   loadname[]="rottgam0.rot";
+   char   *filename;
    int length;
 
    if (quicksaveslot!=-1)
@@ -3456,10 +3460,12 @@ void UndoQuickSaveGame (void)
 
       itoa(quicksaveslot,&loadname[7],16);
       loadname[8]='.';
-      GetPathFromEnvironment( filename, ApogeePath, QUICKSAVEBACKUP );
+      filename = M_StringJoin(ApogeePath, PATH_SEP_STR, QUICKSAVEBACKUP, NULL);
       length=LoadFile(filename,(void **)&buf);
-      GetPathFromEnvironment( filename, ApogeePath, loadname );
+      free(filename)
+      filename = M_StringJoin(ApogeePath, PATH_SEP_STR, loadname, NULL);
       SaveFile(filename,buf,length);
+      free(filename)
       SafeFree(buf);
       AddMessage("Previous Quicksave Game Restored.",MSG_SYSTEM);
       }

--- a/rott/rt_menu.c
+++ b/rott/rt_menu.c
@@ -3397,10 +3397,10 @@ void QuickSaveGame (void)
 
    filename = M_StringJoin(ApogeePath, PATH_SEP_STR, loadname, NULL);
    length=LoadFile(filename,(void **)&buf);
-   free(filename)
+   free(filename);
    filename = M_StringJoin(ApogeePath, PATH_SEP_STR, QUICKSAVEBACKUP, NULL);
    SaveFile(filename,buf,length);
-   free(filename)
+   free(filename);
    SafeFree(buf);
 
    s=&game.picture[0];
@@ -3462,10 +3462,10 @@ void UndoQuickSaveGame (void)
       loadname[8]='.';
       filename = M_StringJoin(ApogeePath, PATH_SEP_STR, QUICKSAVEBACKUP, NULL);
       length=LoadFile(filename,(void **)&buf);
-      free(filename)
+      free(filename);
       filename = M_StringJoin(ApogeePath, PATH_SEP_STR, loadname, NULL);
       SaveFile(filename,buf,length);
-      free(filename)
+      free(filename);
       SafeFree(buf);
       AddMessage("Previous Quicksave Game Restored.",MSG_SYSTEM);
       }

--- a/rott/rt_util.h
+++ b/rott/rt_util.h
@@ -30,6 +30,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define ERRORVERSIONCOL 67
 
 #include "rt_def.h"
+#include "m_misc2.h"
 #include "develop.h"
 
 extern  int    egacolor[16];
@@ -57,7 +58,6 @@ void  *SafeLevelMalloc (long size);
 void  SafeFree (void * ptr);
 long  LoadFile (char *filename, void **bufferptr);
 void  SaveFile (char *filename, void *buffer, long count);
-void  GetPathFromEnvironment( char *fullname, const char *envname, const char *filename );
 void  DefaultExtension (char *path, char *extension);
 void  DefaultPath (char *path, char *basepath);
 void  ExtractFileBase (char *path, char *dest);
@@ -100,8 +100,6 @@ char * UL_GetPath (char * path, char *dir);
 boolean UL_ChangeDirectory (char *path);
 boolean UL_ChangeDrive (char *drive);
 void AbortCheck (char * abortstring);
-
-void FixFilePath(char *filename);
 
 struct dosdate_t
 {

--- a/rott/w_wad.c
+++ b/rott/w_wad.c
@@ -82,7 +82,6 @@ void W_AddFile (char *_filename)
 
         strncpy(filename, _filename, sizeof (filename));
         filename[sizeof (filename) - 1] = '\0';
-        FixFilePath(filename);
 
 		//bna section start
 		if (access (filename, 0) != 0) {

--- a/rott/winrott.c
+++ b/rott/winrott.c
@@ -71,14 +71,6 @@ void SetRottScreenRes (int Width, int Height)
 	
 		dTopYZANGLELIMIT = (90*FINEANGLES/360);;
 	}
-
-	//dYZANGLELIMIT = (12*FINEANGLES/360);
-	//#define YZANGLELIMIT  (12*FINEANGLES/360)//bna--(30*FINEANGLES/360)
-
-	//#define TopYZANGLELIMIT  (44*FINEANGLES/360)//bna added
-
-//	GetCurrentDirectory(sizeof(ApogeePath),ApogeePath);// curent directory name
-
 }
 
 //----------------------------------------------------------------------


### PR DESCRIPTION
Entirely replace calls to the former with `M_StringJoin()`.

The latter shouldn't even be required anymore. "Guessed" file paths will be stored with their actual case, all other file names are either passed by the user (and thus expected to be correctly cased) or generated internally (and thus keep their case).