### PR TITLE
Add support for RottEX map files to rt_ted.c

### DIFF
--- a/rott/_rt_ted.h
+++ b/rott/_rt_ted.h
@@ -28,8 +28,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define SHAREWARE_TAG     0x4d4b
 #define REGISTERED_TAG    0x4344
 #define RTL_VERSION       ( 0x0101 )
+#define RXL_VERSION       ( 0x0200 )
 #define COMMBAT_SIGNATURE ( "RTC" )
 #define NORMAL_SIGNATURE  ( "RTL" )
+#define EXTENDED_COMMBAT_SIGNATURE  ( "RXC" )
+#define EXTENDED_SIGNATURE  ( "RXL" )
 #define RTL_HEADER_OFFSET 8
 
 typedef struct

--- a/rott/rt_ted.c
+++ b/rott/rt_ted.c
@@ -1288,6 +1288,26 @@ void CheckRTLVersion
    //
    SafeRead( filehandle, RTLSignature, sizeof( RTLSignature ) );
 
+   // check if it's from RottEX
+   if ( strcmp( RTLSignature, EXTENDED_SIGNATURE ) == 0
+      || strcmp( RTLSignature, EXTENDED_COMMBAT_SIGNATURE ) == 0 )
+   {
+      // check version number
+      SafeRead( filehandle, &RTLVersion, sizeof( RTLVersion ) );
+      SwapIntelLong((int *)&RTLVersion);
+
+      if (RTLVersion > RXL_VERSION)
+      {
+         Error(
+            "The file '%s' is a version %d.%d %s file.\n"
+            "The highest this version of ROTT can load is %d.%d.", filename,
+            RTLVersion >> 8, RTLVersion & 0xff, RTLSignature,
+            RXL_VERSION >> 8, RXL_VERSION & 0xff );
+      }
+
+      return;
+  }
+
    if ( ( strcmp( RTLSignature, COMMBAT_SIGNATURE ) != 0 ) &&
       ( strcmp( RTLSignature, NORMAL_SIGNATURE ) != 0 ) )
       {
@@ -1311,6 +1331,77 @@ void CheckRTLVersion
    close( filehandle );
    }
 
+/*
+======================
+=
+= GetMapArrayOffset
+=
+======================
+*/
+
+size_t GetMapArrayOffset(char *filename)
+{
+   int filehandle;
+   char RTLSignature[ 4 ];
+   uint64_t ofs_info_headers;
+   uint64_t num_info_headers;
+   int i;
+   char info_header_magic[16];
+   uint64_t info_header_ofs;
+   uint64_t info_header_len;
+   int RTLVersion;
+
+   // open file
+   filehandle = SafeOpenRead( filename );
+
+   // load signature
+   SafeRead( filehandle, RTLSignature, sizeof( RTLSignature ) );
+
+   // check if it's from RottEX
+   if ( strcmp( RTLSignature, EXTENDED_SIGNATURE ) == 0 || strcmp( RTLSignature, EXTENDED_COMMBAT_SIGNATURE ) == 0 )
+   {
+      // check version (it matters)
+      SafeRead( filehandle, &RTLVersion, sizeof( RTLVersion ) );
+
+      // seek to header location
+      lseek( filehandle, 8, SEEK_SET );
+
+      // read offset and num
+      SafeRead( filehandle, &ofs_info_headers, sizeof( ofs_info_headers ) );
+      SafeRead( filehandle, &num_info_headers, sizeof( num_info_headers ) );
+
+      // seek to headers
+      lseek( filehandle, ofs_info_headers, SEEK_SET );
+
+      // read info headers
+      for ( i = 0; i < num_info_headers; i++ )
+      {
+         // read header
+         SafeRead( filehandle, info_header_magic, sizeof( info_header_magic ) );
+         SafeRead( filehandle, &info_header_ofs, sizeof( info_header_ofs ) );
+         SafeRead( filehandle, &info_header_len, sizeof( info_header_len ) );
+
+         // MAPS info header contains reliable offset to data
+         // RXL 1.1 has "MAPSET", RXL 2.0 has "MAPS"
+         if ( ( RTLVersion == RXL_VERSION && strcmp( info_header_magic, "MAPS" ) == 0 )
+            || ( RTLVersion == RTL_VERSION && strcmp( info_header_magic, "MAPSET" ) == 0 ) )
+         {
+            close(filehandle);
+            return info_header_ofs;
+         }
+      }
+
+      // fail
+      close(filehandle);
+      Error( "GetMapArrayOffset: Couldn't find MAPS info header!" );
+      return 0;
+   }
+   else
+   {
+      close(filehandle);
+      return RTL_HEADER_OFFSET;
+   }
+}
 
 /*
 ======================
@@ -1334,14 +1425,16 @@ void ReadROTTMap
    long   expanded;
    int    plane;
    byte  *buffer;
+   size_t mapsoffset;
 
    CheckRTLVersion( filename );
+   mapsoffset = GetMapArrayOffset( filename );
    filehandle = SafeOpenRead( filename );
 
    //
    // Load map header
    //
-   lseek( filehandle, RTL_HEADER_OFFSET + mapnum * sizeof( RTLMap ),
+   lseek( filehandle, mapsoffset + mapnum * sizeof( RTLMap ),
       SEEK_SET );
    SafeRead( filehandle, &RTLMap, sizeof( RTLMap ) );
 
@@ -1494,15 +1587,16 @@ void GetMapFileInfo
    int    filehandle;
    int    i;
    int    nummaps;
+   size_t mapsoffset;
 
    CheckRTLVersion( filename );
-
+   mapsoffset = GetMapArrayOffset( filename );
    filehandle = SafeOpenRead( filename );
 
    //
    // Load map header
    //
-   lseek( filehandle, RTL_HEADER_OFFSET, SEEK_SET );
+   lseek( filehandle, mapsoffset, SEEK_SET );
    SafeRead( filehandle, &RTLMap, sizeof( RTLMap ) );
    close( filehandle );
 
@@ -1580,15 +1674,17 @@ word GetMapCRC
    int  filehandle;
    char filename[ 80 ];
    RTLMAP RTLMap;
+   size_t mapsoffset;
 
    GetMapFileName( &filename[ 0 ] );
    CheckRTLVersion( filename );
+   mapsoffset = GetMapArrayOffset( filename );
    filehandle = SafeOpenRead( filename );
 
    //
    // Load map header
    //
-   lseek( filehandle, RTL_HEADER_OFFSET + num * sizeof( RTLMap ), SEEK_SET );
+   lseek( filehandle, mapsoffset + num * sizeof( RTLMap ), SEEK_SET );
    SafeRead( filehandle, &RTLMap, sizeof( RTLMap ) );
 
    close( filehandle );


### PR DESCRIPTION
Not a big change (the fundamental map format isn't any different), The RottEX level format just includes some extra data structures to store additional information at the end of the file which must be parsed differently.

I have successfully played and tested The Hunt Begins (only available in this new map format) with this change and it loaded and played flawlessly.
