### PR TITLE
rt_in.c: Fix typo in SCANCODE_TO_KEYS_ARRAY

### DIFF
--- a/rott/rt_in.c
+++ b/rott/rt_in.c
@@ -127,7 +127,7 @@ const char ShiftedScanChars[128] =    // Shifted Scan code names with single cha
     0, 0, 0, 0, sc_A, \
     sc_B, sc_C, sc_D, sc_E, sc_F, \
     sc_G, sc_H, sc_I, sc_J, sc_K, \
-    sc_L, sc_L, sc_N, sc_O, sc_P, \
+    sc_L, sc_M, sc_N, sc_O, sc_P, \
     sc_Q, sc_R, sc_S, sc_T, sc_U, \
     sc_V, sc_W, sc_X, sc_Y, sc_Z, \
     sc_1, sc_2, sc_3, sc_4, sc_5, \


### PR DESCRIPTION
Found this while working on my own fork. It prevented some user text input from being taken properly, and perhaps other effects.