### PR TITLE
Fix TARADINO_DATADIR CMake option comparison

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ if(${TARADINO_WARNINGS_AS_ERRORS})
 	endif()
 endif()
 
-if(${TARADINO_DATADIR})
+if(NOT TARADINO_DATADIR STREQUAL "")
 	target_compile_definitions(taradino PRIVATE DATADIR="${TARADINO_DATADIR}")
 endif()
 


### PR DESCRIPTION
In CMake, strings evaluate to false in the context of if commands. Comparison against an empty string must be done explicitly.