### PR TITLE
fix missing limits.h and -lstdc++ for adl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ if(libADLMIDI_FOUND)
 			add_library(libADLMIDI::ADLMIDI ALIAS libADLMIDI::ADLMIDI_static)
 		endif()
 	endif()
-	target_link_libraries(taradino PRIVATE libADLMIDI::ADLMIDI)
+	target_link_libraries(taradino PRIVATE libADLMIDI::ADLMIDI -lstdc++)
 endif()
 
 include(CheckIncludeFile)

--- a/rott/adlmusic.c
+++ b/rott/adlmusic.c
@@ -20,6 +20,7 @@ Copyright (C) 2025 Fabian Greffrath
 
 #include "SDL_mixer.h"
 
+#include <limits.h>
 #include <adlmidi.h>
 
 #include "music.h"

--- a/rott/rt_fixed.h
+++ b/rott/rt_fixed.h
@@ -31,4 +31,8 @@ fixed FixedScale(fixed orig, fixed factor, fixed divisor);
 fixed FixedMulShift(fixed a, fixed b, fixed shift);
 fixed FixedSqrt(fixed n);
 
+#define Fixed2Float(n) _Generic(typeof((n)),  ufixed: (float)((n) * (1.0f / (1 << 16))), \
+                                               fixed: (float)((n) * (1.0f / (1 << 16))))
+#define Float2Fixed(n) _Generic(typeof((n)),   float: (fixed)((n) * (1 << 16)), \
+                                              double: (fixed)((n) * (1 << 16)))
 #endif


### PR DESCRIPTION
Compile and linking fails without adding both.